### PR TITLE
✨ [Feature/114] 토큰 갱신 후 저장 및 프로필 이미지 업데이트 후 반영하기

### DIFF
--- a/src/apis/axios/axiosConfig.ts
+++ b/src/apis/axios/axiosConfig.ts
@@ -27,6 +27,7 @@ const getAuthValue = async (token: string | undefined | null): Promise<string> =
           refreshToken: useLogin.getState().refreshToken,
         })
       ).data;
+      useLogin.setState({ accessToken: responseData.accessToken });
       authValue = responseData.accessToken;
     }
   }

--- a/src/app/auth/kakao/KakaoRedirectPage.tsx
+++ b/src/app/auth/kakao/KakaoRedirectPage.tsx
@@ -9,7 +9,7 @@ import Spinner from "@/components/Spinner";
 
 const KakaoRedirectPage = () => {
   const searchParams = useSearchParams();
-  const { setToken } = useLogin();
+  const { setToken, setImageUrl } = useLogin();
 
   useEffect(() => {
     const callApi = async () => {
@@ -18,6 +18,7 @@ const KakaoRedirectPage = () => {
         const redirectUri = `${process.env.NEXT_PUBLIC_BASE_URL}/auth/kakao`;
         const res = await signInWithProvider("KAKAO", code, redirectUri);
         setToken(res.accessToken, res.refreshToken);
+        setImageUrl(res.user.image);
       }
     };
     callApi();

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -3,7 +3,6 @@
 import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
 
-import { me } from "@/apis/usersApi";
 import { cn } from "@/utils/cn";
 
 import useLogin from "../Login/useLogin";
@@ -15,8 +14,7 @@ const Header: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
-  const { accessToken } = useLogin();
-  const [imgSrc, setImgSrc] = useState<string | null>(null);
+  const { accessToken, imageUrl } = useLogin();
 
   useEffect(() => {
     const checkAuthStatus = () => {
@@ -36,23 +34,6 @@ const Header: React.FC = () => {
       document.removeEventListener("mousedown", handleClickOutside);
     };
   }, []);
-
-  useEffect(() => {
-    const fetchUserImage = async () => {
-      if (accessToken) {
-        try {
-          const user = await me();
-          if (user && user.image) {
-            setImgSrc(user.image);
-          }
-        } catch (error) {
-          console.log("사용자 정보를 가져오는 중 오류 발생:", error);
-          setImgSrc(null);
-        }
-      }
-    };
-    fetchUserImage();
-  }, [accessToken]);
 
   return (
     <div
@@ -84,7 +65,7 @@ const Header: React.FC = () => {
                 }
               }}
             >
-              <ProfileCircle imageUrl={imgSrc} size="mobile" />
+              <ProfileCircle imageUrl={imageUrl} size="mobile" />
             </div>
             <div ref={containerRef} aria-expanded={isOpen} className="relative">
               {isOpen && <ProfileDropDown />}

--- a/src/components/Login/SigninForm.tsx
+++ b/src/components/Login/SigninForm.tsx
@@ -22,13 +22,14 @@ const SigninForm = () => {
     handleSubmit,
   } = useForm<LoginFormInput>({ mode: "all" });
   const router = useRouter();
-  const { setToken } = useLogin();
+  const { setToken, setImageUrl } = useLogin();
 
   const onSubmit: SubmitHandler<LoginFormInput> = async (data) => {
     const res = await signIn(data.email, data.password, () =>
       setError("email", { type: "custom", message: "이메일 혹은 비밀번호를 확인해주세요." })
     );
     setToken(res.accessToken, res.refreshToken);
+    setImageUrl(res.user.image);
     router.push("/");
   };
 

--- a/src/components/Login/SignupForm.tsx
+++ b/src/components/Login/SignupForm.tsx
@@ -29,7 +29,7 @@ const SignupForm: React.FC = () => {
   } = useForm<FormInput>({ mode: "all" });
   const password = watch("password");
   const router = useRouter();
-  const { login, setToken } = useLogin();
+  const { login, setToken, setImageUrl } = useLogin();
 
   useEffect(() => {
     if (login()) {
@@ -48,6 +48,7 @@ const SignupForm: React.FC = () => {
       }
     );
     setToken(res.accessToken, res.refreshToken);
+    setImageUrl(res.user.image);
     router.push("/");
   };
 

--- a/src/components/Login/useLogin.tsx
+++ b/src/components/Login/useLogin.tsx
@@ -27,7 +27,7 @@ const useLogin = create<LoginState>()(
       setImageUrl: (imageUrl) => {
         set((prev) => ({
           ...prev,
-          imageUrl: imageUrl ?? get().imageUrl,
+          imageUrl,
         }));
       },
       clear: () => set({ accessToken: undefined, refreshToken: undefined }),

--- a/src/components/Login/useLogin.tsx
+++ b/src/components/Login/useLogin.tsx
@@ -4,7 +4,9 @@ import { persist } from "zustand/middleware";
 interface LoginState {
   accessToken?: string;
   refreshToken?: string;
+  imageUrl?: string | null;
   setToken: (accessToken?: string, refreshToken?: string) => void;
+  setImageUrl: (imageUrl: string | null) => void;
   clear: () => void;
   login: () => boolean;
 }
@@ -14,11 +16,19 @@ const useLogin = create<LoginState>()(
     (set, get) => ({
       accessToken: undefined,
       refreshToken: undefined,
+      imageUrl: null,
       setToken: (accessToken = undefined, refreshToken = undefined) => {
-        set({
+        set((prev) => ({
+          ...prev,
           accessToken: accessToken ?? get().accessToken,
           refreshToken: refreshToken ?? get().refreshToken,
-        });
+        }));
+      },
+      setImageUrl: (imageUrl) => {
+        set((prev) => ({
+          ...prev,
+          imageUrl: imageUrl ?? get().imageUrl,
+        }));
       },
       clear: () => set({ accessToken: undefined, refreshToken: undefined }),
       login: () => get().accessToken !== undefined && get().refreshToken !== undefined,

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 
 import { uploadImage } from "@/apis/imagesApi";
 import { me, updateUserProfile } from "@/apis/usersApi";
+import useLogin from "@/components/Login/useLogin";
 import { User } from "@/types/User";
 
 interface UseProfileReturn {
@@ -30,6 +31,7 @@ export const useProfile = (): UseProfileReturn => {
   const [isUpdating, setIsUpdating] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const { setImageUrl } = useLogin();
 
   // 사용자 정보 가져오기
   const getUserInfo = async () => {
@@ -78,6 +80,7 @@ export const useProfile = (): UseProfileReturn => {
 
       // 프로필 업데이트 API 호출
       await updateUserProfile(inputNickName, uploadedImageUrl);
+      setImageUrl(uploadedImageUrl);
 
       // 상태 업데이트
       const updatedUserInfo: User = {


### PR DESCRIPTION
## 📝 Summary
Resolves: #114 
<!-- 간단한 변경 요약을 작성해주세요 -->

토큰 갱신 후 저장 및 프로필 이미지 업데이트 후 반영하기

## 🔧 Changes

<!-- 주요 변경 내용을 항목별로 작성해주세요 -->

- Access Token 갱신 후 zustand로 영속화하도록 변경
- 프로필 이미지 업데이트 시 헤더 프로필 이미지도 변경되도록 수정
-

## ✅ Checklist

- [x] 코드 컨벤션을 준수하였습니다.
- [x] 변경 사항을 충분히 테스트하였습니다.
- [x] 설명을 명확하게 작성하였습니다.
- [x] 올바른 브랜치에 PR을 생성하였습니다.
- [x] 🤞 리뷰어의 마음을 사로잡았습니다.

## 🚀 Test Plan

<!-- 테스트 방법과 결과를 작성해주세요 -->

-

## 🖼️ Screenshots (UI 변경 시)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

| 변경 전 | 변경 후 |
| ------- | ------- |
| 이미지  | 이미지  |

## 📚 추가 정보

<!-- 리뷰어가 참고하면 좋을 추가 정보를 적어주세요 -->

- 이 PR은 다크호스일지도... 🎩✨

---

> 🚨 _"모든 PR에는 커피가 필요하다!"_ ☕

- [bugfix pr 템플릿](?expand=1&template=bugfix_template.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 로그인 상태에 사용자 프로필 이미지 URL 저장 기능이 추가되었습니다.
    - 카카오 로그인, 일반 로그인, 회원가입, 프로필 변경 시 사용자 이미지가 자동으로 로그인 상태에 반영됩니다.

- **리팩터**
    - 헤더에서 사용자 이미지 표시 방식이 개선되어, 별도의 API 호출 없이 로그인 상태의 이미지 URL을 직접 사용합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->