### PR TITLE
🐛 [Fix/113] 프로필 와인/리뷰 수정 후 새로고침

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -17,7 +17,11 @@ const Footer: React.FC = () => {
           rel="noopener noreferrer"
           target="_blank"
         >
-          <img alt="github-icon" className="size-[1.25rem]" src="/images/github.png" />
+          <img
+            alt="github-icon"
+            className="size-[1.25rem] select-none pointer-events-none"
+            src="/images/github.png"
+          />
           <span>GitHub</span>
         </a>
       </div>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -64,7 +64,11 @@ const Header: React.FC = () => {
     >
       <div className="w-full flex items-center justify-between">
         <Link href="/">
-          <img alt="logo image" className="w-[3.25rem]" src="/images/logo.png" />
+          <img
+            alt="logo image"
+            className="w-[3.25rem] select-none pointer-events-none"
+            src="/images/logo.png"
+          />
         </Link>
         {loading ? (
           <Spinner className="border-white border-r-black" />

--- a/src/components/Login/Signin.tsx
+++ b/src/components/Login/Signin.tsx
@@ -22,7 +22,11 @@ export default function Login() {
     <div className="flex items-center justify-center">
       <div className="bg-white border border-solid border-gray300 px-[3rem] py-[5rem] rounded-2xl">
         <div className="w-[25rem] flex flex-col items-center">
-          <img alt="logo-image" className="w-[6.5rem]" src="/images/logo-2x.png" />
+          <img
+            alt="logo-image"
+            className="w-[6.5rem] select-none pointer-events-none"
+            src="/images/logo-2x.png"
+          />
           <SigninForm />
           <Button
             className="w-full mt-[0.5rem] border border-solid border-gray300"

--- a/src/components/Login/Signup.tsx
+++ b/src/components/Login/Signup.tsx
@@ -5,7 +5,11 @@ const Signup: React.FC = () => {
     <div className="flex items-center justify-center">
       <div className="bg-white border border-solid border-gray300 px-[3rem] py-[5rem] rounded-2xl">
         <div className="w-[25rem] flex flex-col items-center">
-          <img alt="logo-image" className="w-[6.5rem]" src="/images/logo-2x.png" />
+          <img
+            alt="logo-image"
+            className="w-[6.5rem] select-none pointer-events-none"
+            src="/images/logo-2x.png"
+          />
           <SignupForm />
           <div className="mt-[2.5rem] text-gray500">
             계정이 이미 있으신가요? <a className="text-purple underline font-medium">로그인하기</a>

--- a/src/components/about-wine/MiniWineCard.tsx
+++ b/src/components/about-wine/MiniWineCard.tsx
@@ -15,7 +15,7 @@ export default function MiniWineCard({ wine }: Props) {
       <div className="shrink-0">
         <img
           alt={wine.name}
-          className="w-[2.75rem] h-[10.0625rem] object-cover object-bottom"
+          className="w-[2.75rem] h-[10.0625rem] object-cover object-bottom select-none pointer-events-none"
           src={wine.image}
         />
       </div>

--- a/src/components/about-wine/WineCard.tsx
+++ b/src/components/about-wine/WineCard.tsx
@@ -16,7 +16,7 @@ const WineCard: React.FC<WineCardProps> = ({ data }) => {
         {data.image ? (
           <img
             alt={data.name}
-            className="w-[12.5rem] h-[13.0625rem] object-contain object-bottom"
+            className="w-[12.5rem] h-[13.0625rem] object-contain object-bottom select-none pointer-events-none"
             src={data.image}
           />
         ) : (

--- a/src/components/about-wine/WineInfoCard.tsx
+++ b/src/components/about-wine/WineInfoCard.tsx
@@ -24,7 +24,7 @@ export default function WineInfoCard({ data }: Props) {
           {data.image ? (
             <img
               alt={data.name}
-              className="w-[4rem] h-[10rem] sm:w-[10rem] sm:h-[11rem] md:w-[12rem] md:h-[12.5rem] lg:w-[12.5rem] lg:h-[13.0625rem] object-contain object-bottom"
+              className="w-[4rem] h-[10rem] sm:w-[10rem] sm:h-[11rem] md:w-[12rem] md:h-[12.5rem] lg:w-[12.5rem] lg:h-[13.0625rem] object-contain object-bottom select-none pointer-events-none"
               src={data.image}
             />
           ) : (

--- a/src/components/dropdown/ReviewDropDown.tsx
+++ b/src/components/dropdown/ReviewDropDown.tsx
@@ -43,7 +43,7 @@ export default function ReviewDropDown({
       alert(MESSAGES.UNAUTHORIZED_EDIT);
       return;
     }
-    open("editReview", <ReviewEditModal reviewId={reviewId} />);
+    open("editReview", <ReviewEditModal refresh={refresh} reviewId={reviewId} />);
     onEdit?.();
   };
 

--- a/src/components/dropdown/WineDropDown.tsx
+++ b/src/components/dropdown/WineDropDown.tsx
@@ -23,7 +23,7 @@ export default function WineDropDown({
   const { open, close } = useModalStore();
 
   const handleEdit = async () => {
-    open("editWine", <WineEditModal wineId={wineId} />);
+    open("editWine", <WineEditModal refresh={refresh} wineId={wineId} />);
     onEdit?.();
   };
 

--- a/src/components/input/FileInput.tsx
+++ b/src/components/input/FileInput.tsx
@@ -107,7 +107,7 @@ export default function FileInput({ currentImage, onImageChange }: FileInputProp
           {imagePreview && !imageError ? (
             <img
               alt="프로필 이미지"
-              className="w-full h-full object-cover rounded-full"
+              className="w-full h-full object-cover rounded-full select-none pointer-events-none"
               src={imagePreview}
               onError={handleImageError}
               onLoad={handleImageLoad}

--- a/src/components/modal/WineEditModal.tsx
+++ b/src/components/modal/WineEditModal.tsx
@@ -27,9 +27,10 @@ interface Wine {
 interface WineEditModalProps {
   wineId: number;
   initialWineData?: Wine;
+  refresh?: () => Promise<void>;
 }
 
-export default function WineEditModal({ wineId, initialWineData }: WineEditModalProps) {
+export default function WineEditModal({ wineId, initialWineData, refresh }: WineEditModalProps) {
   const { close } = useModalStore();
   const [name, setName] = useState("");
   const [price, setPrice] = useState("");
@@ -136,6 +137,8 @@ export default function WineEditModal({ wineId, initialWineData }: WineEditModal
       };
 
       await patchWine(wineId, wineData);
+      await refresh?.();
+
       alert("와인 정보가 수정되었습니다.");
       close();
     } catch (err) {

--- a/src/components/modal/WineEditModal.tsx
+++ b/src/components/modal/WineEditModal.tsx
@@ -203,7 +203,7 @@ export default function WineEditModal({ wineId, initialWineData }: WineEditModal
           {imagePreview ? (
             <img
               alt="미리보기"
-              className="w-full h-full object-cover pointer-events-none rounded-md"
+              className="w-full h-full object-cover pointer-events-none rounded-md select-none"
               src={imagePreview}
             />
           ) : (

--- a/src/components/modal/WinePostModal.tsx
+++ b/src/components/modal/WinePostModal.tsx
@@ -115,7 +115,7 @@ export default function WinePostModal({ onSuccess }: { onSuccess?: () => void })
           {imagePreview ? (
             <img
               alt="미리보기"
-              className="w-full h-full object-cover pointer-events-none"
+              className="w-full h-full object-cover pointer-events-none select-none"
               src={imagePreview}
             />
           ) : (

--- a/src/components/profile/MyWineCard.tsx
+++ b/src/components/profile/MyWineCard.tsx
@@ -106,7 +106,7 @@ function WineCardContent({ wine }: { wine: BaseWineData }) {
   return (
     <div className="flex gap-6 items-center max-md:gap-5">
       {/* 와인 이미지 - 고정 크기 */}
-      <div className="flex-shrink-0 w-50 h-52 max-md:w-15 max-md:h-40 bg-white rounded-md overflow-hidden flex items-center justify-center text-gray-400 text-sm">
+      <div className="flex-shrink-0 w-50 h-52 max-md:w-15 max-md:h-40 bg-white rounded-md overflow-hidden flex items-center justify-center text-gray-400 text-sm select-none pointer-events-none">
         {wine.image ? (
           <div className="w-full h-full flex items-center justify-center">
             <img

--- a/src/components/profile/ProfileCircle.tsx
+++ b/src/components/profile/ProfileCircle.tsx
@@ -16,7 +16,7 @@ export default function ProfileCircle({ imageUrl, size = "default" }: ProfileCir
       {imageUrl ? (
         <img
           alt="사용자 프로필"
-          className="w-full h-full rounded-full object-cover border-[1.5px] border-gray-300"
+          className="w-full h-full rounded-full object-cover border-[1.5px] border-gray-300 select-none pointer-events-none"
           src={imageUrl}
         />
       ) : (

--- a/src/components/wine-detail/review-modal/ReviewEditModal.tsx
+++ b/src/components/wine-detail/review-modal/ReviewEditModal.tsx
@@ -16,9 +16,10 @@ import ReviewTop from "./ReviewTop";
 
 interface ReviewEditModalProps {
   reviewId: number;
+  refresh?: () => Promise<void>;
 }
 
-export default function ReviewEditModal({ reviewId }: ReviewEditModalProps) {
+export default function ReviewEditModal({ reviewId, refresh }: ReviewEditModalProps) {
   const { close } = useModalStore();
   const isMobile = useMediaQuery("(max-width: 24.375rem)");
   const size = isMobile ? "lg" : "xl";
@@ -97,6 +98,11 @@ export default function ReviewEditModal({ reviewId }: ReviewEditModalProps) {
   const updateCaches = useCallback(
     async (updatedReview: Review) => {
       if (!wine?.id) return;
+
+      // 프로필 페이지의 리뷰 수정
+      if (refresh) {
+        await refresh();
+      }
 
       try {
         // 개별 리뷰 캐시 업데이트


### PR DESCRIPTION
## 📝 Summary

- 프로필 와인/리뷰 수정 후 새로고침 및 이미지 드래그 방지 추가

## 🔧 Changes

- 프로필 와인/리뷰 수정 후 새로고침
- 이미지 드래그 방지 추가

## ✅ Checklist

- [ ] 코드 컨벤션을 준수하였습니다.
- [ ] 변경 사항을 충분히 테스트하였습니다.
- [ ] 설명을 명확하게 작성하였습니다.
- [ ] 올바른 브랜치에 PR을 생성하였습니다.
- [ ] 🤞 리뷰어의 마음을 사로잡았습니다.

## 🚀 Test Plan

<!-- 테스트 방법과 결과를 작성해주세요 -->

- 이미지 드래그 및 블록 방지
- 프로필 페이지 와인/리뷰 수정 후 모달 닫혔을 때 즉시 반영 확인

## 🖼️ Screenshots (UI 변경 시)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

| 변경 전 | 변경 후 |
| ------- | ------- |
| 이미지  | 이미지  |

## 📚 추가 정보

<!-- 리뷰어가 참고하면 좋을 추가 정보를 적어주세요 -->

- 이 PR은 다크호스일지도... 🎩✨

---

> 🚨 _"모든 PR에는 커피가 필요하다!"_ ☕

- [bugfix pr 템플릿](?expand=1&template=bugfix_template.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **스타일**
	- 여러 이미지 및 이미지 컨테이너에 선택 방지(select-none) 및 포인터 이벤트 비활성화(pointer-events-none) 스타일이 적용되어, 이미지를 선택하거나 클릭하는 등의 상호작용이 불가능하도록 개선되었습니다.

- **신규 기능**
	- 리뷰 및 와인 편집 모달에서 새로고침(refresh) 동작이 추가되어, 수정 후 자동으로 최신 정보가 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->